### PR TITLE
Change file extension to .tibasic

### DIFF
--- a/grammars/tibasic.cson
+++ b/grammars/tibasic.cson
@@ -5,10 +5,10 @@
 # May get updated later for the TI68k and TI-NSpire Basic stuff
 # Version 3 of this file
 
-'scopeName': 'source.8xp'
-'name': 'Ti-Basic'
+'name': 'TI-Basic'
+'scopeName': 'source.tibasic'
 'fileTypes': [
-  'extension'
+  '8xp'
 ]
 'patterns': [
   {

--- a/snippets/language-tibasic.cson
+++ b/snippets/language-tibasic.cson
@@ -1,7 +1,7 @@
 # If you want some example snippets, check out:
 # https://github.com/atom/language-javascript/blob/master/snippets/javascript.cson
 
-'.source.8xp':
+'.source.tibasic':
   # A
   'Absolute Value':
     'prefix': 'abs'

--- a/spec/language-tibasic-spec.coffee
+++ b/spec/language-tibasic-spec.coffee
@@ -9,8 +9,8 @@ describe "TiBasic grammar", ->
       atom.packages.activatePackage("language-tibasic")
 
     runs ->
-      grammar = atom.syntax.grammarForScopeName("source.8xp")
+      grammar = atom.syntax.grammarForScopeName("source.tibasic")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
-    expect(grammar.scopeName).toBe "source.8xp"
+    expect(grammar.scopeName).toBe "source.tibasic"


### PR DESCRIPTION
Added 8xp filetype to grammar so when program files are opened atom will select tibasic.
Also changed source.8xp some places where it should be source.tibasic, as source really has nothing to do with filetype but language. Doesn't make or break anything, just more better.